### PR TITLE
[fix 19, 32] Fixing visuals from userUpdatepage and roleUpdatepage

### DIFF
--- a/src/Pages/Protected/Roles/RolesUpdatePage/index.jsx
+++ b/src/Pages/Protected/Roles/RolesUpdatePage/index.jsx
@@ -58,12 +58,18 @@ export default function RolesUpdatePage() {
             moduleNameMap[permission.module.toLowerCase()] ||
             permission.module.toLowerCase();
 
-          permission.access.forEach((access) => {
-            const index = accessIndexMap[access];
-            if (index !== undefined) {
-              permissionsMap[moduleName][index] = true;
-            }
-          });
+          if (permissionsMap[moduleName]) {
+            permission.access.forEach((access) => {
+              const index = accessIndexMap[access];
+              if (index !== undefined) {
+                permissionsMap[moduleName][index] = true;
+              }
+            });
+          } else {
+            console.warn(
+              `Módulo desconhecido encontrado: ${permission.module}`
+            );
+          }
         });
 
         setFinanceiro(permissionsMap.finance);

--- a/src/Pages/Protected/Roles/RolesUpdatePage/index.test.jsx
+++ b/src/Pages/Protected/Roles/RolesUpdatePage/index.test.jsx
@@ -194,4 +194,36 @@ describe("RolesUpdatePage", () => {
     // Verifica se o modal de sucesso foi exibido
     expect(screen.getByText("PERFIL DELETADO COM SUCESSO")).toBeInTheDocument();
   });
+
+  it("displays warning when an unknown module is encountered", async () => {
+    // Espiona a função console.warn
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Mock da função getRoleById para retornar um módulo desconhecido
+    getRoleById.mockResolvedValue({
+      name: "Admin",
+      permissions: [
+        { module: "unknown_module", access: ["create", "read"] }, // Módulo desconhecido
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={[{ state: { roleId: "mock-role-id" } }]}>
+        <Routes>
+          <Route path="/" element={<RolesUpdatePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Aguarda a execução do efeito
+    await waitFor(() => {
+      // Verifica se console.warn foi chamado com a mensagem esperada
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Módulo desconhecido encontrado: unknown_module"
+      );
+    });
+
+    // Limpa o mock do console.warn
+    warnSpy.mockRestore();
+  });
 });

--- a/src/Pages/Protected/Users/userUpdatePage/index.jsx
+++ b/src/Pages/Protected/Users/userUpdatePage/index.jsx
@@ -49,6 +49,7 @@ export default function UserUpdatePage() {
     loadRoles();
   }, []);
 
+  //Puxa os dados ded usuário para atualizar a página
   useEffect(() => {
     const fetchUser = async () => {
       if (userId) {

--- a/src/Pages/Protected/Users/userUpdatePage/index.test.jsx
+++ b/src/Pages/Protected/Users/userUpdatePage/index.test.jsx
@@ -123,7 +123,7 @@ describe("UserUpdatePage", () => {
       phone: "1234567890",
       status: true,
       email: "john.doe@example.com",
-      role: "1",
+      role: { _id: "1" },
     });
 
     setup();
@@ -149,7 +149,7 @@ describe("UserUpdatePage", () => {
           email: "jane.doe@example.com",
           phone: "0987654321",
           status: true,
-          role: "1",
+          role: { _id: "1" },
         },
         "mock-token"
       );
@@ -167,7 +167,7 @@ describe("UserUpdatePage", () => {
       phone: "1234567890",
       status: true,
       email: "john.doe@example.com",
-      role: "1",
+      role: { _id: "1" },
     });
 
     setup();
@@ -186,8 +186,8 @@ describe("UserUpdatePage", () => {
           nomeCompleto: "John Doe",
           celular: "1234567890",
           email: "john.doe@example.com",
-          login: "Ativo", // ou o estado correto
-          perfilSelecionado: "", // Ajuste conforme o valor real esperado
+          login: "Ativo",
+          perfilSelecionado: "1",
         },
       }
     );

--- a/src/Pages/Protected/Users/userUpdatePage/index.test.jsx
+++ b/src/Pages/Protected/Users/userUpdatePage/index.test.jsx
@@ -187,7 +187,7 @@ describe("UserUpdatePage", () => {
           celular: "1234567890",
           email: "john.doe@example.com",
           login: "Ativo", // ou o estado correto
-          perfilSelecionado: "1",
+          perfilSelecionado: "", // Ajuste conforme o valor real esperado
         },
       }
     );


### PR DESCRIPTION
Foram concertados os testes de UserUpdate que estavam desatualizados. 

Também na página de RoleUpdate foram concertados os visuais que haviam quebrado no MVP, foi mudado o UserEffect que preenchia as checkboxs, além de concertar um teste e adicionar um teste extra na página.